### PR TITLE
Public url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# ngrok token
+server/lib/token.py

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Además, es necesario setear el token de autorización de `ngrok`. En `https://n
 NGROK_TOKEN = "<your-token>"
 ```
 
+Al tratar de conectarse siendo cliente se le pedirá que ingrese manualmente la dirección y el puerto del servidor al conectarse.
+
 La aplicación está basada en una arquitectura Cliente-Servidor, donde no se tiene una Base de Datos que almacene los datos a largo plazo. También para la comunicación privada entre dos personas se utiliza la arquitectura P2P, donde un cliente le pide al servidor que le comunique con el otro cliente para que este último abra un socket y así nuestro primer cliente pueda conectarse a este socket y así hablar directamente con el cliente saltandose así al servidor.
 
 Para ejecutar la aplicación es necesario ejecutar primero el servidor, para esto nos colocamos en el directorio del servidor y ejecutamos el código de este:

--- a/README.md
+++ b/README.md
@@ -11,13 +11,21 @@ Librerías utilizadas:
   `signal`: Para poder manejar las interrupciones por teclado y evitar que se caiga la app.  
   `sys`: Para obtener los parametros entregados en la linea de comando.  
   `collection`: Sacamos la implementación de *stack* para tener todos los mensajes.
+  `pyngrok`: Para manejar la conexión mediante una URL pública.
 
 Para instalar las librerías, puedes correr el comando en esta carpeta:
 
 ```bash
 pip install -r requirements.txt
 ```
-  
+
+Además, es necesario setear el token de autorización de `ngrok`. En `https://ngrok.com/` se puede crear una cuenta gratuita y el token de autorización se encuentra en `https://dashboard.ngrok.com/get-started/your-authtoken`. Con el token, ahora se debe crear el archivo `server/lib/token.py`, e insertar la variable ```NGROK_TOKEN``` con el valor del token, de la forma:
+
+``` python 
+# server/lib/token.py
+NGROK_TOKEN = "<your-token>"
+```
+
 La aplicación está basada en una arquitectura Cliente-Servidor, donde no se tiene una Base de Datos que almacene los datos a largo plazo. También para la comunicación privada entre dos personas se utiliza la arquitectura P2P, donde un cliente le pide al servidor que le comunique con el otro cliente para que este último abra un socket y así nuestro primer cliente pueda conectarse a este socket y así hablar directamente con el cliente saltandose así al servidor.
 
 Para ejecutar la aplicación es necesario ejecutar primero el servidor, para esto nos colocamos en el directorio del servidor y ejecutamos el código de este:
@@ -41,3 +49,5 @@ Luego, abrimos la terminal en el directorio del cliente y ejectamos el código d
 cd client
 python3 ./main.py
 ```
+
+La primera vez corriendo el servidor, se va a descargar ```ngrok```.

--- a/client/main.py
+++ b/client/main.py
@@ -3,11 +3,11 @@ from lib.client import Client
 
 
 if __name__ == "__main__":
-    # server's IP address
-    # if the server is not on this machine, 
-    # put the private (network) IP address (e.g 192.168.1.2)
-    SERVER_HOST = "127.0.0.1"
-    SERVER_PORT = 5002 # server's port
     separator_token = "<SEP>" # we will use this to separate the client name & message
+
+    # URL and PORT are provided during server initialization
+    SERVER_HOST = input("Indicate server URL: ")
+    SERVER_PORT = int(input("Indicate PORT: "))
+
     client = Client(SERVER_HOST, SERVER_PORT, separator_token)
     client.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 sockets
 colorama
+pyngrok

--- a/server/main.py
+++ b/server/main.py
@@ -1,6 +1,7 @@
 # Código recuperado de https://www.thepythoncode.com/article/make-a-chat-room-application-in-python
 from lib.helpers import process_args
 from lib.server import Server
+from pyngrok import ngrok
 
 if __name__ == "__main__":
     n_clients, n_arg = process_args()
@@ -9,4 +10,11 @@ if __name__ == "__main__":
     SERVER_PORT = 5002 # port we want to use
     separator_token = "<SEP>" # we will use this to separate the client name & message
     server = Server(n_clients, n_arg, SERVER_HOST, SERVER_PORT, separator_token)
+
+    # Set up an ngrok tunnel to connect a public URL to localhost
+    ssh_tunnel = ngrok.connect(SERVER_PORT, "tcp")
+    print("URL:", ssh_tunnel.public_url.split('/')[-1].split(':')[0])
+    print("PORT:", ssh_tunnel.public_url.split(':')[-1])
+
     server.run()
+    ngrok.kill()

--- a/server/main.py
+++ b/server/main.py
@@ -1,6 +1,7 @@
 # Código recuperado de https://www.thepythoncode.com/article/make-a-chat-room-application-in-python
 from lib.helpers import process_args
 from lib.server import Server
+from lib.token import NGROK_TOKEN
 from pyngrok import ngrok
 
 if __name__ == "__main__":
@@ -12,6 +13,7 @@ if __name__ == "__main__":
     server = Server(n_clients, n_arg, SERVER_HOST, SERVER_PORT, separator_token)
 
     # Set up an ngrok tunnel to connect a public URL to localhost
+    ngrok.set_auth_token(NGROK_TOKEN)
     ssh_tunnel = ngrok.connect(SERVER_PORT, "tcp")
     print("URL:", ssh_tunnel.public_url.split('/')[-1].split(':')[0])
     print("PORT:", ssh_tunnel.public_url.split(':')[-1])


### PR DESCRIPTION
Implementéel uso de una URL pública que sirve de túnel para comunicar cualquier cliente a localhost. Todo lo maneja la librería `pyngrok` por detrás. Uno se debe crear una cuenta gratuita en `ngrok.com` e ingresar el token que entrega (explicado en el README).

Como la versión gratuita de `ngrok`cambia la URL y el puerto cada vez que se inicia el servidor, hice que ahora se le pregunte al cliente la URL y el puerto a conectarse.

(ejemplo de la inicialización del server)
 ![image](https://user-images.githubusercontent.com/58240958/132258364-ff3d8552-1db5-476b-8841-1c01260e2db3.png)

(ejemplo de la conexión del cliente)
![image](https://user-images.githubusercontent.com/58240958/132258460-a41f6182-847d-451d-9d0b-8d2e12e3183f.png)
