### PR TITLE
Readme & buf fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Aplicación que permite hacer un chat en formato LAN utilizando URL y puertos. E
   - [Ejecución](#ejecución)
     - [Servidor](#servidor)
     - [Cliente](#cliente)
+  - [Comandos](#comandos)
+  - [Migraciones de procesos](#migraciones)
+    - [Consideraciones](#consideraciones)
 
 ## Instalación
 
@@ -76,6 +79,10 @@ donde N es la cantidad de clientes que se deben conectar para poder mostrar los 
 
 **La primera vez corriendo el servidor, se va a descargar `ngrok`.**
 
+### Comandos
+
+En el chat puedes escribir el comando /help para ver todos los comandos disponibles.
+
 ### Cliente
 
 Abrimos la terminal en la raiz del repositorio y ejectamos lo siguiente:
@@ -85,4 +92,18 @@ cd client
 python3 ./main.py
 ```
 
-Si es que no se automatizó el ingreso de la URL y el puerto se pedirán estas al iniciar el cliente
+Si es que no se automatizó el ingreso de la URL y el puerto se pedirán estas al iniciar el cliente.
+
+## Migraciones de Procesos
+
+Cada 30 segundos el servidor intenta migrar hacia un cliente. Si es que hay algún cliente conectado, entonces se inicia un proceso de cambio migración de proceso, en donde se informa en un JSON todo el estado actual del chat. Todo esta información se guarda en un objeto `SubServer` que se encarga de toda la lógica del servidor. Cada 30 segundos, el cliente intenta migrar hacia otro cliente. Si es que hay más clientes, se elige uno aleatoriamente, y se hace el mismo proceso de migración. El cliente que dejó de actuar de servidor elimina el objeto `SubServer`, deshaciéndose de todas las referencias de estado de proceso.
+
+### Consideraciones
+
+Para que nuevos clientes puedan ingresar al chat aún cuando no conocen el cliente que es servidor, estos clientes se intentan conectar al servidor original, y éste los redirige a quien es el servidor actual para que se maneje el ingreso del cliente.
+
+Ésto implica que se debe mantiene la referencia de quien es el servidor actual en el servidor original, por lo que para cada migración de procesos además se le informa al servidor original quién es el nuevo servidor.
+
+Si el servidor original se desconecta, entonces ya no se permite la entrada de nuevos usuarios.
+
+Cuando un cliente-servidor se intenta de desconectar con Ctrl-c, se fuerza la migración de servidor (si es que hay más clientes), aún si no pasaron los 30 segundos.

--- a/client/lib/client.py
+++ b/client/lib/client.py
@@ -135,7 +135,6 @@ class Client:
                 print(msg)
             elif id == "server":
                 self.become_server(msg)
-                # falta la recepción del estado del proceso
             elif id == "new_server":
                 self.server_id = msg
 
@@ -143,15 +142,14 @@ class Client:
         info = json.loads(msg)
         self.server = SubServer(info, self.users, self.p2p, self)
         self.is_server = True
-        # print("voy a ser server!!")
         self.timer = Thread(target=self.change_server)
         self.timer.daemon = True
         self.timer.start()
 
     def change_server(self, closing = False):
         while self.is_server:
-            if not closing: sleep(10)
-            # sleep(30)
+            if not closing: sleep(30)
+
             if self.server.number_clients > 0:
                 try:
                     user = random.choice(list(self.users))
@@ -175,4 +173,3 @@ class Client:
                 self.p2p.pm(user, "server-" + json.dumps(info))
 
                 del self.server
-                # print(f"cambiando de server a {self.users[user]['name']}")

--- a/client/lib/client.py
+++ b/client/lib/client.py
@@ -81,6 +81,7 @@ class Client:
                     self.change_server(closing=True)
                 # Cerrar socket
                 print("cerrando...")
+                sleep(0.1)
                 self.send("k-dead")
 
                 self.p2p.die()
@@ -172,4 +173,6 @@ class Client:
                 info['enough_clients'] = self.server.enough_clients
 
                 self.p2p.pm(user, "server-" + json.dumps(info))
+
+                del self.server
                 # print(f"cambiando de server a {self.users[user]['name']}")

--- a/server/lib/server.py
+++ b/server/lib/server.py
@@ -123,8 +123,8 @@ class Server:
 
     def change_server(self):
         while self.server:
-            sleep(10)
-            # sleep(30)
+            sleep(30)
+
             if self.number_clients > 0:
                 user = random.choice(list(self.clients.values()))
                 self.server = False


### PR DESCRIPTION
Arreglé un error que de vez en cuando, cuando un cliente-servidor se desconectaba y se forzaba la migración de server, se caía todo. Pasaba porque se mandaba el mensaje de "muerte del cliente" antes que el nuevo server pueda terminar de iniciar su proceso de server. La solución ser hizo metiendo un pequeño sleep antes de mandar el mensaje de morir.

Además comenté un poco de la implementación que hicimos de la migración de proceso en el README.

Por último, quité unos comentarios innecesarios (tipo prints comentados).